### PR TITLE
style fix for width overflow with Chrome scrollbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         color: #6ca5ab;
       }
       main {
-        width: 100vw;
+        width: 100%;
         height: 100vh;
       }
       .flex {


### PR DESCRIPTION
The issue happens on Windows Chrome with scrollbar.
100vw exceeds viewport's width when there has scrollbar 17px.